### PR TITLE
missing exports inside package.json zshy setup snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,9 @@ pnpm add --save-dev zshy
   "name": "my-pkg",
   "version": "1.0.0",
 + "zshy": {
-+   ".": "./src/index.ts"
++   "exports" : {
++     ".": "./src/index.ts"
++   }
 + }
 }
 ```


### PR DESCRIPTION
Hello, 
thanks for this tiny library!

While following the setup instructions, I ran into an error on the initial build:

```text
→  Missing "exports" key in package.json#/zshy
```

It appears to originate from this line:

https://github.com/colinhacks/zshy/blob/f4cc85cfb4ff00f53e48d9332358456501188952/src/main.ts#L171-L173

Since I copied the script directly from the README, I assume the instructions may be slightly out of date. 
This PR addresses and resolves the issue.