### PR TITLE
feat: add windows support

### DIFF
--- a/src/compile.ts
+++ b/src/compile.ts
@@ -239,9 +239,10 @@ export async function compileProject(config: ProjectOptions, entryPoints: string
 
         // Create the destination path in outDir, maintaining the same relative structure
         const destFile = path.resolve(config.compilerOptions.outDir, assetPath);
+        const posixDestFile = utils.toPosix(destFile);
 
         // Skip if this asset has already been copied
-        if (ctx.copiedAssets.has(destFile)) {
+        if (ctx.copiedAssets.has(posixDestFile)) {
           continue;
         }
 
@@ -250,8 +251,8 @@ export async function compileProject(config: ProjectOptions, entryPoints: string
         // Track the file that would be copied
         // Use posix paths here because typescript also outputs them posix
         // style.
-        ctx.writtenFiles.add(utils.toPosix(destFile));
-        ctx.copiedAssets.add(destFile);
+        ctx.writtenFiles.add(posixDestFile);
+        ctx.copiedAssets.add(posixDestFile);
 
         if (!config.dryRun) {
           // Ensure destination directory exists
@@ -262,8 +263,8 @@ export async function compileProject(config: ProjectOptions, entryPoints: string
         }
 
         if (config.verbose) {
-          const relativeSource = config.pkgJsonDir ? utils.toPosix(path.relative(config.pkgJsonDir, sourceFile)) : sourceFile;
-          const relativeDest = config.pkgJsonDir ? utils.toPosix(path.relative(config.pkgJsonDir, destFile)) : destFile;
+          const relativeSource = config.pkgJsonDir ? utils.relativePosix(config.pkgJsonDir, sourceFile) : sourceFile;
+          const relativeDest = config.pkgJsonDir ? utils.relativePosix(config.pkgJsonDir, destFile) : destFile;
           utils.emojiLog(
             "📄",
             `${config.dryRun ? "[dryrun] " : ""}Copied asset: ./${relativeSource} → ./${relativeDest}`

--- a/src/compile.ts
+++ b/src/compile.ts
@@ -248,7 +248,9 @@ export async function compileProject(config: ProjectOptions, entryPoints: string
         const destDir = path.dirname(destFile);
 
         // Track the file that would be copied
-        ctx.writtenFiles.add(destFile);
+        // Use posix paths here because typescript also outputs them posix
+        // style.
+        ctx.writtenFiles.add(utils.toPosix(destFile));
         ctx.copiedAssets.add(destFile);
 
         if (!config.dryRun) {
@@ -260,8 +262,8 @@ export async function compileProject(config: ProjectOptions, entryPoints: string
         }
 
         if (config.verbose) {
-          const relativeSource = config.pkgJsonDir ? path.relative(config.pkgJsonDir, sourceFile) : sourceFile;
-          const relativeDest = config.pkgJsonDir ? path.relative(config.pkgJsonDir, destFile) : destFile;
+          const relativeSource = config.pkgJsonDir ? utils.toPosix(path.relative(config.pkgJsonDir, sourceFile)) : sourceFile;
+          const relativeDest = config.pkgJsonDir ? utils.toPosix(path.relative(config.pkgJsonDir, destFile)) : destFile;
           utils.emojiLog(
             "📄",
             `${config.dryRun ? "[dryrun] " : ""}Copied asset: ./${relativeSource} → ./${relativeDest}`

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,7 +5,7 @@ import { globby } from "globby";
 import { table } from "table";
 import * as ts from "typescript";
 import { type BuildContext, compileProject } from "./compile.js";
-import { emojiLog, formatForLog, isSourceFile, readTsconfig, removeExtension, toPosix } from "./utils.js";
+import { emojiLog, formatForLog, isSourceFile, readTsconfig, removeExtension, toPosix, relativePosix } from "./utils.js";
 
 export async function main(): Promise<void> {
   ///////////////////////////////////
@@ -138,7 +138,7 @@ Examples:
   // console.log("📦 Extracting entry points from package.json exports...");
   const pkgJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf-8"));
   const pkgJsonDir = path.dirname(packageJsonPath);
-  const pkgJsonRelPath = toPosix(path.relative(pkgJsonDir, packageJsonPath));
+  const pkgJsonRelPath = relativePosix(pkgJsonDir, packageJsonPath);
 
   // print project root
   emojiLog("⚙️", `Detected project root: ${pkgJsonDir}`);
@@ -266,7 +266,7 @@ Examples:
     emojiLog("❌", `tsconfig.json not found at ${toPosix(path.resolve(tsconfigPath))}`, "error");
     process.exit(1);
   }
-  emojiLog("📁", `Reading tsconfig from ./${toPosix(path.relative(pkgJsonDir, tsconfigPath))}`);
+  emojiLog("📁", `Reading tsconfig from ./${relativePosix(pkgJsonDir, tsconfigPath)}`);
 
   // if (_parsedConfig.rootDir) {
   // 	console.error(
@@ -286,9 +286,9 @@ Examples:
   delete _parsedConfig.customConditions; //  can't be set for CommonJS builds
 
   const outDir = path.resolve(pkgJsonDir, _parsedConfig?.outDir || "./dist");
-  const relOutDir = toPosix(path.relative(pkgJsonDir, outDir));
+  const relOutDir = relativePosix(pkgJsonDir, outDir);
   const declarationDir = path.resolve(pkgJsonDir, _parsedConfig?.declarationDir || relOutDir);
-  const relDeclarationDir = toPosix(path.relative(pkgJsonDir, declarationDir));
+  const relDeclarationDir = relativePosix(pkgJsonDir, declarationDir);
 
   const tsconfigJson: ts.CompilerOptions = {
     ..._parsedConfig,
@@ -466,7 +466,7 @@ Examples:
         : process.cwd();
   }
 
-  const relRootDir = toPosix(path.relative(pkgJsonDir, rootDir));
+  const relRootDir = relativePosix(pkgJsonDir, rootDir);
 
   //////////////////////////////////
   ///   display resolved paths   ///
@@ -628,7 +628,7 @@ Examples:
 
       // Sort files by relative path for consistent display
       const sortedFiles = [...buildContext.writtenFiles]
-        .map((file) => toPosix(path.relative(pkgJsonDir, file)))
+        .map((file) => relativePosix(pkgJsonDir, file))
         .sort()
         .map((relPath) => (relPath.startsWith(".") ? relPath : `./${relPath}`));
 
@@ -657,8 +657,8 @@ Examples:
       const relSourcePath = path.relative(rootDir, absSourcePath);
       const absJsPath = path.resolve(outDir, relSourcePath);
       const absDtsPath = path.resolve(declarationDir, relSourcePath);
-      let relJsPath = "./" + toPosix(path.relative(pkgJsonDir, absJsPath));
-      let relDtsPath = "./" + toPosix(path.relative(pkgJsonDir, absDtsPath));
+      let relJsPath = "./" + relativePosix(pkgJsonDir, absJsPath);
+      let relDtsPath = "./" + relativePosix(pkgJsonDir, absDtsPath);
 
       if (typeof sourcePath === "string") {
         if (sourcePath.endsWith("/*") || sourcePath.endsWith("/**/*")) {
@@ -742,7 +742,7 @@ Examples:
           const absSourcePath = path.resolve(pkgJsonDir, sourcePath);
           const relSourcePath = path.relative(rootDir, absSourcePath);
           const absJsPath = path.resolve(outDir, relSourcePath);
-          const relJsPath = "./" + toPosix(path.relative(pkgJsonDir, absJsPath));
+          const relJsPath = "./" + relativePosix(pkgJsonDir, absJsPath);
 
           // Use CommonJS entrypoint for bin
           const binPath = removeExtension(relJsPath) + (isTypeModule ? `.cjs` : `.js`);

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,11 +1,11 @@
 import * as fs from "node:fs";
-import * as path from "node:path/posix";
+import * as path from "node:path";
 import parseArgs from "arg";
 import { globby } from "globby";
 import { table } from "table";
 import * as ts from "typescript";
 import { type BuildContext, compileProject } from "./compile.js";
-import { emojiLog, formatForLog, isSourceFile, readTsconfig, removeExtension } from "./utils.js";
+import { emojiLog, formatForLog, isSourceFile, readTsconfig, removeExtension, toPosix } from "./utils.js";
 
 export async function main(): Promise<void> {
   ///////////////////////////////////
@@ -138,10 +138,11 @@ Examples:
   // console.log("📦 Extracting entry points from package.json exports...");
   const pkgJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf-8"));
   const pkgJsonDir = path.dirname(packageJsonPath);
+  const pkgJsonRelPath = toPosix(path.relative(pkgJsonDir, packageJsonPath));
 
   // print project root
   emojiLog("⚙️", `Detected project root: ${pkgJsonDir}`);
-  emojiLog("📦", `Reading package.json from ./${path.relative(pkgJsonDir, packageJsonPath)}`);
+  emojiLog("📦", `Reading package.json from ./${pkgJsonRelPath}`);
 
   /////////////////////////////////
   ///    parse zshy config      ///
@@ -262,10 +263,10 @@ Examples:
   const _parsedConfig = readTsconfig(tsconfigPath);
   if (!fs.existsSync(tsconfigPath)) {
     // Check if tsconfig.json exists
-    emojiLog("❌", `tsconfig.json not found at ${path.resolve(tsconfigPath)}`, "error");
+    emojiLog("❌", `tsconfig.json not found at ${toPosix(path.resolve(tsconfigPath))}`, "error");
     process.exit(1);
   }
-  emojiLog("📁", `Reading tsconfig from ./${path.relative(pkgJsonDir, tsconfigPath)}`);
+  emojiLog("📁", `Reading tsconfig from ./${toPosix(path.relative(pkgJsonDir, tsconfigPath))}`);
 
   // if (_parsedConfig.rootDir) {
   // 	console.error(
@@ -285,9 +286,9 @@ Examples:
   delete _parsedConfig.customConditions; //  can't be set for CommonJS builds
 
   const outDir = path.resolve(pkgJsonDir, _parsedConfig?.outDir || "./dist");
-  const relOutDir = path.relative(pkgJsonDir, outDir);
+  const relOutDir = toPosix(path.relative(pkgJsonDir, outDir));
   const declarationDir = path.resolve(pkgJsonDir, _parsedConfig?.declarationDir || relOutDir);
-  const relDeclarationDir = path.relative(pkgJsonDir, declarationDir);
+  const relDeclarationDir = toPosix(path.relative(pkgJsonDir, declarationDir));
 
   const tsconfigJson: ts.CompilerOptions = {
     ..._parsedConfig,
@@ -465,7 +466,7 @@ Examples:
         : process.cwd();
   }
 
-  const relRootDir = path.relative(pkgJsonDir, rootDir);
+  const relRootDir = toPosix(path.relative(pkgJsonDir, rootDir));
 
   //////////////////////////////////
   ///   display resolved paths   ///
@@ -627,7 +628,7 @@ Examples:
 
       // Sort files by relative path for consistent display
       const sortedFiles = [...buildContext.writtenFiles]
-        .map((file) => path.relative(pkgJsonDir, file))
+        .map((file) => toPosix(path.relative(pkgJsonDir, file)))
         .sort()
         .map((relPath) => (relPath.startsWith(".") ? relPath : `./${relPath}`));
 
@@ -656,8 +657,8 @@ Examples:
       const relSourcePath = path.relative(rootDir, absSourcePath);
       const absJsPath = path.resolve(outDir, relSourcePath);
       const absDtsPath = path.resolve(declarationDir, relSourcePath);
-      let relJsPath = "./" + path.relative(pkgJsonDir, absJsPath);
-      let relDtsPath = "./" + path.relative(pkgJsonDir, absDtsPath);
+      let relJsPath = "./" + toPosix(path.relative(pkgJsonDir, absJsPath));
+      let relDtsPath = "./" + toPosix(path.relative(pkgJsonDir, absDtsPath));
 
       if (typeof sourcePath === "string") {
         if (sourcePath.endsWith("/*") || sourcePath.endsWith("/**/*")) {
@@ -741,7 +742,7 @@ Examples:
           const absSourcePath = path.resolve(pkgJsonDir, sourcePath);
           const relSourcePath = path.relative(rootDir, absSourcePath);
           const absJsPath = path.resolve(outDir, relSourcePath);
-          const relJsPath = "./" + path.relative(pkgJsonDir, absJsPath);
+          const relJsPath = "./" + toPosix(path.relative(pkgJsonDir, absJsPath));
 
           // Use CommonJS entrypoint for bin
           const binPath = removeExtension(relJsPath) + (isTypeModule ? `.cjs` : `.js`);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -77,3 +77,5 @@ export function isAssetFile(filePath: string): boolean {
   if (ext === "") return false;
   return !jsExtensions.has(ext);
 }
+
+export const toPosix = (p: string): string => p.replaceAll(path.sep, path.posix.sep);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -79,3 +79,8 @@ export function isAssetFile(filePath: string): boolean {
 }
 
 export const toPosix = (p: string): string => p.replaceAll(path.sep, path.posix.sep);
+
+export const relativePosix = (from: string, to: string): string => {
+  const relativePath = path.relative(from, to);
+  return toPosix(relativePath);
+};

--- a/test/zshy.test.ts
+++ b/test/zshy.test.ts
@@ -69,6 +69,7 @@ describe("zshy with different tsconfig configurations", () => {
         args.push("--dry-run");
       }
       const result = spawnSync("tsx", args, {
+        shell: true,
         encoding: "utf8",
         timeout: 30000, // Increase timeout for CI
         cwd: process.cwd() + "/test", // Use relative path that works in CI
@@ -142,12 +143,13 @@ describe("zshy with different tsconfig configurations", () => {
 });
 
 function normalizeOutput(output: string): string {
+  const slashPattern = /[\\\/]+/g;
   return (
     output
-      // Normalize file paths to be relative and use forward slashes
-      .replace(/\/Users\/[^/]+\/[^/\s]+\/projects\/zshy/g, "<root>")
-      // Normalize any absolute paths
-      .replace(/\/[^\s]+\/zshy/g, "<root>")
+      // Loosely normalize path sep to `/`. Note that we also normalize double
+      // escaped backslashes since we `JSON.stringify` some paths in the output.
+      .replaceAll(slashPattern, "/")
+      .replaceAll(process.cwd().replaceAll(slashPattern, '/'), "<root>")
       // Normalize timestamps and timing info
       .replace(/\d+ms/g, "<time>")
       // Normalize any specific file counts that might vary


### PR DESCRIPTION
This adds support for windows by using OS specific paths for all
non-relative, non-typescript-host usages.

Open to suggestions if there's any way we can tidy this a bit more. Basically,
it works like this:

- All paths we perform FS operations on should be OS-specific
- All paths we render in the output and files should be posix
- The written files set needs to be posix because it seems TS host emits them
this way too
