### PR TITLE
feat: allow only config.bin

### DIFF
--- a/test/zshy.test.ts
+++ b/test/zshy.test.ts
@@ -143,13 +143,13 @@ describe("zshy with different tsconfig configurations", () => {
 });
 
 function normalizeOutput(output: string): string {
-  const slashPattern = /[\\\/]+/g;
+  const slashPattern = /[\\/]+/g;
   return (
     output
       // Loosely normalize path sep to `/`. Note that we also normalize double
       // escaped backslashes since we `JSON.stringify` some paths in the output.
       .replaceAll(slashPattern, "/")
-      .replaceAll(process.cwd().replaceAll(slashPattern, '/'), "<root>")
+      .replaceAll(process.cwd().replaceAll(slashPattern, "/"), "<root>")
       // Normalize timestamps and timing info
       .replace(/\d+ms/g, "<time>")
       // Normalize any specific file counts that might vary


### PR DESCRIPTION
Closes #22 

I have changed `src/main.ts` to allow only `bin` to be defined. I had trouble implementing a Jest test because I couldn't quite figure out how the testing harness works in this repo..

I tested the implementation by making a subdirectory with the following files:

`package.json`:
```json
{
    "name": "my-cli",
    "zshy": {
        "bin": "./cli.ts"
    }
}
```

`tsconfig.json`:
```json5
{
  "description": "Test: Basic configuration with only bin.",
  "compilerOptions": {
    "outDir": "./dist",
    "rootDir": "."
  },
  "include": ["./cli.ts"],
  "exclude": ["node_modules", "dist"]
}
```

`cli.ts` (copied from `test/src/cli.ts`):
```ts
#!/usr/bin/env node

console.log("Hello, world!");
process.exit(0);
```

And running a newly-built version of `zshy` produces the expected results.

Please feel free to modify this PR as you see fit. The `binConfigured` flag is not the cleanest implementation, so I am open to suggestions for improvement.