### PR TITLE
feat: add `--dev` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@
 - 👑 **Powered by `tsc`** — The gold standard for TypeScript transpilation
 - 📦 **Bundler-free** — No bundler or bundler configs involved
 - 🟦 **No config file** — Reads from your `package.json` and `tsconfig.json`
+- 🔗 **No rebuild/watch modes** — Use `--dev` to symlink dist to source for live development
 - 📝 **Declarative entrypoint map** — Specify your TypeScript entrypoints in `package.json#/zshy`
 - 🤖 **Auto-generated `"exports"`** — Writes `"exports"` map directly into your `package.json`
 - 🧱 **Dual-module builds** — Builds ESM and CJS outputs from a single TypeScript source file
@@ -207,6 +208,7 @@ Options:
   -h, --help                        Show this help message
   -p, --project <path>              Path to tsconfig (default: ./tsconfig.json)
       --verbose                     Enable verbose output
+      --dev                         Enable development mode (symlink dist to source)
       --dry-run                     Don't write any files or update package.json
       --fail-threshold <threshold>  When to exit with non-zero error code
                                       "error" (default)

--- a/src/main.ts
+++ b/src/main.ts
@@ -676,8 +676,10 @@ Examples:
     // ESM linking
     emojiLog("🔗", "Linking ESM... (symlinking dist to source)");
 
-    const patterns: string[] = ["**/*.{ts,tsx,mts,cts}", "!**/*.d.ts", "!**/*.d.mts", "!**/*.d.cts"];
-    const files = await globby(patterns, { cwd: rootDir, dot: false });
+    const files = await globby(["**/*.{ts,tsx,mts,cts}", "!**/*.d.ts", "!**/*.d.mts", "!**/*.d.cts"], {
+      cwd: rootDir,
+      dot: false,
+    });
 
     for (const file of files) {
       const source = path.resolve(rootDir, file);

--- a/src/main.ts
+++ b/src/main.ts
@@ -683,9 +683,9 @@ Examples:
 
     for (const file of files) {
       const source = path.resolve(rootDir, file);
-      fs.mkdirSync(outDir, { recursive: true });
       const dest = removeExtension(path.resolve(outDir, file));
       try {
+        fs.mkdirSync(outDir, { recursive: true });
         fs.symlinkSync(source, dest + ".js", "file");
         fs.symlinkSync(source, dest + ".d.ts", "file");
       } catch {}


### PR DESCRIPTION
Resolves #32.

Adds a `--dev` flag which symlinks dist to source. No need for rebuild or watch tools.