### PR TITLE
Fix CJS default export should work when exporting named types

### DIFF
--- a/src/tx-analyze-exports.ts
+++ b/src/tx-analyze-exports.ts
@@ -25,11 +25,11 @@ export const analyzeExports = (
       defaultExportNode = node;
     }
     // 3) named re-exports (`export { a, b } from …` or `export { x }`)
-    else if (ts.isExportDeclaration(node) && node.exportClause) {
+    else if (ts.isExportDeclaration(node) && node.exportClause && !node.isTypeOnly) {
       hasNamedExports = true;
     }
     // 3a) export * from "module" - also counts as named exports
-    else if (ts.isExportDeclaration(node) && !node.exportClause && node.moduleSpecifier) {
+    else if (ts.isExportDeclaration(node) && !node.exportClause && node.moduleSpecifier && !node.isTypeOnly) {
       hasNamedExports = true;
     }
     // 4) named `export const/let/var …`


### PR DESCRIPTION
## Problem

When you have a default export without any named exports except types:
```ts
function hello() {
  console.log('hello');
}

export default hello;
export type NamedType = 'named1';
```

The built `.cjs` code should be:
```js
function hello() {
  console.log('hello');
}
exports.default = hello;
module.exports = exports.default;
```

And the associated `.d.cts` should be:
```ts
declare function hello(): void;
export = hello;
export type NamedType = 'named1';
```

However, it seems the check for named exports does not check for type only exports so we actually get this for the built `.cjs` code:

```js
function hello() {
  console.log('hello');
}
exports.default = hello;
```

## Solution

Add a check for type only exports and ignore those.

## Notes

I haven't found a way to test this with your test setup. I'd be happy to contribute more tests with some guidance.
However, I checked the result on a test project successfully.