### PR TITLE
Allow to configure the log verbosity level

### DIFF
--- a/src/compile.ts
+++ b/src/compile.ts
@@ -127,7 +127,7 @@ export async function compileProject(config: ProjectOptions, entryPoints: string
     }
 
     if (errorCount > 0 || warningCount > 0) {
-      utils.emojiLog("⚠️", `Found ${errorCount} error(s) and ${warningCount} warning(s)`, "warn");
+      utils.log.warn(`Found ${errorCount} error(s) and ${warningCount} warning(s)`);
     }
 
     // Format diagnostics with color and context like tsc, keeping original order
@@ -182,7 +182,7 @@ export async function compileProject(config: ProjectOptions, entryPoints: string
   // Add CJS interop transformer for single default exports
   if (config.cjsInterop && config.format === "cjs") {
     if (config.verbose) {
-      utils.emojiLog("🔄", `Enabling CJS interop transform...`);
+      utils.log.info(`Enabling CJS interop transform...`);
     }
     before.push(createCjsInteropTransformer());
   }
@@ -200,7 +200,7 @@ export async function compileProject(config: ProjectOptions, entryPoints: string
   });
 
   if (emitResult.emitSkipped) {
-    utils.emojiLog("❌", "Emit was skipped due to errors", "error");
+    utils.log.error("Emit was skipped due to errors");
   } else {
     // console.log(`✅ Emitted ${config.jsExtension} and ${config.dtsExtension}
     // files`);
@@ -221,10 +221,8 @@ export async function compileProject(config: ProjectOptions, entryPoints: string
     ctx.errorCount += emitErrors.length;
     ctx.warningCount += emitWarnings.length;
 
-    utils.emojiLog(
-      "❌",
-      `Found ${emitErrors.length} error(s) and ${emitWarnings.length} warning(s) during emit:`,
-      "error"
+    utils.log.error(
+      `Found ${emitErrors.length} error(s) and ${emitWarnings.length} warning(s) during emit:`
     );
     console.log();
 
@@ -247,7 +245,7 @@ export async function compileProject(config: ProjectOptions, entryPoints: string
   // Copy assets if any were found and rootDir is provided
   if (assetImports.size > 0) {
     if (config.verbose) {
-      utils.emojiLog("📄", `Found ${assetImports.size} asset import(s), copying to output directory...`);
+      utils.log.info(`Found ${assetImports.size} asset import(s), copying to output directory...`);
     }
 
     // utils.copyAssets(assetImports, config, ctx);
@@ -258,7 +256,7 @@ export async function compileProject(config: ProjectOptions, entryPoints: string
 
         if (!fs.existsSync(sourceFile)) {
           if (config.verbose) {
-            utils.emojiLog("⚠️", `Asset not found: ${assetPath} (resolved to ${sourceFile})`, "warn");
+            utils.log.warn(`Asset not found: ${assetPath} (resolved to ${sourceFile})`);
           }
           continue;
         }
@@ -291,13 +289,12 @@ export async function compileProject(config: ProjectOptions, entryPoints: string
         if (config.verbose) {
           const relativeSource = config.pkgJsonDir ? utils.relativePosix(config.pkgJsonDir, sourceFile) : sourceFile;
           const relativeDest = config.pkgJsonDir ? utils.relativePosix(config.pkgJsonDir, destFile) : destFile;
-          utils.emojiLog(
-            "📄",
+          utils.log.info(
             `${config.dryRun ? "[dryrun] " : ""}Copied asset: ./${relativeSource} → ./${relativeDest}`
           );
         }
       } catch (error) {
-        utils.emojiLog("❌", `Failed to copy asset ${assetPath}: ${error}`, "error");
+        utils.log.error(`Failed to copy asset ${assetPath}: ${error}`);
       }
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,10 @@
 #!/usr/bin/env node
 
 import { main } from "./main.js";
-import { emojiLog } from "./utils.js";
+import { log } from "./utils.js";
 
 // Run the script
 main().catch((error) => {
-  emojiLog("❌", `Build failed: ${error}`, "error");
+  log.error(`Build failed: ${error}`);
   process.exit(1);
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -5,9 +5,34 @@ export function formatForLog(data: unknown) {
   return JSON.stringify(data, null, 2).split("\n").join("\n   ");
 }
 
-export function emojiLog(_emoji: string, content: string, level: "log" | "warn" | "error" = "log") {
-  console[level]("»  " + content);
+// Global logging state
+let isSilent = false;
+
+export function setSilent(silent: boolean) {
+  isSilent = silent;
 }
+
+export const log = {
+  prefix: undefined as string | undefined,
+
+  info: function (message: string) {
+    if (!isSilent) {
+      console.log((this.prefix || "") + message);
+    }
+  },
+
+  error: function (message: string) {
+    if (!isSilent) {
+      console.error((this.prefix || "") + message);
+    }
+  },
+
+  warn: function (message: string) {
+    if (!isSilent) {
+      console.warn((this.prefix || "") + message);
+    }
+  },
+};
 
 export function isSourceFile(filePath: string): boolean {
   // Declaration files are not source files
@@ -56,7 +81,7 @@ export function readTsconfig(tsconfigPath: string) {
   );
 
   if (parsedConfig.errors.length > 0) {
-    emojiLog("❌", "Error parsing tsconfig.json:", "error");
+    log.error("Error parsing tsconfig.json:");
     for (const error of parsedConfig.errors) {
       console.error(
         ts.formatDiagnostic(error, {
@@ -70,7 +95,7 @@ export function readTsconfig(tsconfigPath: string) {
   }
 
   if (!parsedConfig.options) {
-    emojiLog("❌", "Error reading tsconfig.json#/compilerOptions", "error");
+    log.error("Error reading tsconfig.json#/compilerOptions");
     process.exit(1);
   }
   return parsedConfig.options!;

--- a/test/__snapshots__/zshy.test.ts.snap
+++ b/test/__snapshots__/zshy.test.ts.snap
@@ -1169,7 +1169,7 @@ exports[`zshy with different tsconfig configurations > should work with flat bui
    }
 »  Reading tsconfig from ./tsconfig.json
 »  You're building your code to the project root. This means your compiled files will be generated alongside your source files.
-   Ensure that your "files" in package.json excludes TypeScript source files, or your users may experience .d.ts resolution issues in some environments:
+   Ensure that your "files" in package.json does not include TypeScript source files, or your users may experience .d.ts resolution issues in some environments:
      "files": ["**/*.js", "**/*.mjs", "**/*.cjs", "**/*.d.ts", "**/*.d.mts", "**/*.d.cts"]
 »  Determining entrypoints...
    ╔══════════╤════════════════╗


### PR DESCRIPTION
## Problem

The current output is quite verbose even without the `--verbose` flag. This pollutes CI logs with unnecessary lines.

## Solution

- Introduce a `--verbosity` argument that can be `verbose`, `normal` or `silent`. It takes precedence over the `--verbose` flag if both are set.
- `--verbose` is still supported and used if `--verbosity` is not set
- Keep error and warnings logs even in `silent` mode

Fixes #49 