### PR TITLE
fix: expand wildcard exports in jsr config

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -37,6 +37,49 @@ interface NormalizedConfig {
   noEdit: boolean;
 }
 
+type JsrExportEntry = {
+  exportPath: string;
+  sourcePath: string;
+};
+
+function getWildcardExportKey(exportPath: string, sourcePath: string): string {
+  return `${exportPath}\0${sourcePath}`;
+}
+
+function expandWildcardExportPath(exportPath: string, sourcePattern: string, sourceFile: string): string {
+  const posixSourcePattern = toPosix(sourcePattern);
+  const posixSourceFile = toPosix(sourceFile);
+  const sourceBase = posixSourcePattern.endsWith("/**/*")
+    ? posixSourcePattern.slice(0, -5)
+    : posixSourcePattern.slice(0, -2);
+  const sourceSubpath = posixSourceFile.startsWith(`${sourceBase}/`)
+    ? posixSourceFile.slice(sourceBase.length + 1)
+    : posixSourceFile;
+
+  return exportPath.replace("*", removeExtension(sourceSubpath));
+}
+
+function createJsrExports(
+  configExports: Record<string, string>,
+  expandedWildcardExports: Map<string, JsrExportEntry[]>
+): Record<string, string> {
+  const jsrExports: Record<string, string> = {};
+
+  for (const [exportPath, sourcePath] of Object.entries(configExports)) {
+    if (exportPath.includes("*") || sourcePath.includes("*")) {
+      const entries = expandedWildcardExports.get(getWildcardExportKey(exportPath, sourcePath)) ?? [];
+      for (const entry of entries) {
+        jsrExports[entry.exportPath] = entry.sourcePath;
+      }
+      continue;
+    }
+
+    jsrExports[exportPath] = sourcePath;
+  }
+
+  return jsrExports;
+}
+
 export async function main(): Promise<void> {
   log.prefix = "»  ";
 
@@ -432,6 +475,7 @@ Examples:
   }
   const entryPoints: string[] = [];
   const assetEntrypoints: Array<{ exportPath: string; sourcePath: string }> = [];
+  const expandedWildcardExports = new Map<string, JsrExportEntry[]>();
 
   const rows: string[][] = [["Subpath", "Entrypoint"]];
 
@@ -473,6 +517,13 @@ Examples:
         // Filter out test files (__tests__ directories, .test.*, .spec.*)
         const filteredFiles = wildcardFiles.filter((file) => !isTestFile(file));
         entryPoints.push(...filteredFiles);
+        expandedWildcardExports.set(
+          getWildcardExportKey(exportPath, sourcePath),
+          filteredFiles.map((file) => ({
+            exportPath: expandWildcardExportPath(exportPath, sourcePath, file),
+            sourcePath: file,
+          }))
+        );
 
         rows.push([`"${cleanExportPath}"`, `${sourcePath} (${filteredFiles.length} matches)`]);
       } else if (isSourceFile(sourcePath)) {
@@ -1081,8 +1132,8 @@ Examples:
         log.info(`Reading jsr.json from ./${jsrJsonRelPath}`);
       }
 
-      // Copy exports from zshy config to jsr.json exports
-      const jsrExports = config.exports;
+      // JSR does not accept wildcard exports, so expand them to explicit source entrypoints.
+      const jsrExports = createJsrExports(config.exports, expandedWildcardExports);
       jsrJson.exports = jsrExports;
       if (isVerbose) {
         log.info(`Setting "exports": ${formatForLog(jsrExports)}`);

--- a/test/__snapshots__/zshy.test.ts.snap
+++ b/test/__snapshots__/zshy.test.ts.snap
@@ -338,6 +338,14 @@ exports[`zshy with different tsconfig configurations > should reproduce issue #5
        "require": "./dist/components/*"
      }
    }
+»  Updating jsr.json...
+»  Reading jsr.json from ./jsr.json
+»  Setting "exports": {
+     ".": "./src/index.ts",
+     "./utils/math": "./src/utils/math.ts",
+     "./utils/string": "./src/utils/string.ts",
+     "./components/button": "./src/components/button.ts"
+   }
 »  Build complete!",
 }
 `;

--- a/test/__snapshots__/zshy.test.ts.snap
+++ b/test/__snapshots__/zshy.test.ts.snap
@@ -15,16 +15,19 @@ exports[`zshy with different tsconfig configurations > should copy exports to js
 »  Reading package.json from ./package.json
 »  Parsed zshy config: {
      "exports": {
-       ".": "./src/index.ts"
+       ".": "./src/index.ts",
+       "./features/*": "./src/*"
      }
    }
 »  Reading tsconfig from ./tsconfig.json
 »  Determining entrypoints...
-   ╔══════════╤════════════════╗
-   ║ Subpath  │ Entrypoint     ║
-   ╟──────────┼────────────────╢
-   ║ "my-pkg" │ ./src/index.ts ║
-   ╚══════════╧════════════════╝
+»  Matching glob: ./src/*.{ts,tsx,mts,cts}
+   ╔═════════════════════╤═════════════════════╗
+   ║ Subpath             │ Entrypoint          ║
+   ╟─────────────────────┼─────────────────────╢
+   ║ "my-pkg"            │ ./src/index.ts      ║
+   ║ "my-pkg/features/*" │ ./src/* (1 matches) ║
+   ╚═════════════════════╧═════════════════════╝
 »  Resolved build paths:
    ╔══════════╤═══════════════╗
    ║ Location │ Resolved path ║
@@ -92,12 +95,18 @@ exports[`zshy with different tsconfig configurations > should copy exports to js
        "types": "./dist/index.d.cts",
        "import": "./dist/index.js",
        "require": "./dist/index.cjs"
+     },
+     "./features/*": {
+       "types": "./dist/*",
+       "import": "./dist/*",
+       "require": "./dist/*"
      }
    }
 »  Updating jsr.json...
 »  Reading jsr.json from ./jsr.json
 »  Setting "exports": {
-     ".": "./src/index.ts"
+     ".": "./src/index.ts",
+     "./features/index": "./src/index.ts"
    }
 »  Build complete!",
 }

--- a/test/ignore-tests/jsr.json
+++ b/test/ignore-tests/jsr.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://jsr.io/schema/config-file.v1.json",
+  "name": "@jsr/test-ignore-tests",
+  "version": "1.0.0",
+  "exports": {
+    ".": "./src/index.ts",
+    "./utils/math": "./src/utils/math.ts",
+    "./utils/string": "./src/utils/string.ts",
+    "./components/button": "./src/components/button.ts"
+  }
+}

--- a/test/jsr/jsr.json
+++ b/test/jsr/jsr.json
@@ -3,6 +3,7 @@
 	"name": "@jsr/my-pkg",
 	"version": "1.0.0",
 	"exports": {
-		".": "./src/index.ts"
+		".": "./src/index.ts",
+		"./features/index": "./src/index.ts"
 	}
 }

--- a/test/jsr/package.json
+++ b/test/jsr/package.json
@@ -11,7 +11,8 @@
   },
   "zshy": {
     "exports": {
-      ".": "./src/index.ts"
+      ".": "./src/index.ts",
+      "./features/*": "./src/*"
     }
   },
   "files": [
@@ -25,6 +26,11 @@
       "types": "./dist/index.d.cts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
+    },
+    "./features/*": {
+      "types": "./dist/*",
+      "import": "./dist/*",
+      "require": "./dist/*"
     }
   }
 }

--- a/test/zshy.test.ts
+++ b/test/zshy.test.ts
@@ -229,10 +229,20 @@ describe("zshy with different tsconfig configurations", () => {
   });
 
   it("should reproduce issue #53 - test files in __tests__ directories are included in build", () => {
+    const cwd = process.cwd() + "/test/ignore-tests";
     const snapshot = runZshyWithTsconfig("tsconfig.json", {
       dryRun: false,
-      cwd: process.cwd() + "/test/ignore-tests",
+      cwd,
     });
+
+    const jsrJson = JSON.parse(readFileSync(`${cwd}/jsr.json`, "utf-8"));
+    expect(jsrJson.exports).toEqual({
+      ".": "./src/index.ts",
+      "./utils/math": "./src/utils/math.ts",
+      "./utils/string": "./src/utils/string.ts",
+      "./components/button": "./src/components/button.ts",
+    });
+
     expect(snapshot).toMatchSnapshot();
   });
 });

--- a/test/zshy.test.ts
+++ b/test/zshy.test.ts
@@ -174,10 +174,18 @@ describe("zshy with different tsconfig configurations", () => {
   });
 
   it("should copy exports to jsr.json when jsr.json exists", () => {
+    const cwd = process.cwd() + "/test/jsr";
     const snapshot = runZshyWithTsconfig("tsconfig.json", {
       dryRun: false,
-      cwd: process.cwd() + "/test/jsr",
+      cwd,
     });
+
+    const jsrJson = JSON.parse(readFileSync(`${cwd}/jsr.json`, "utf-8"));
+    expect(jsrJson.exports).toEqual({
+      ".": "./src/index.ts",
+      "./features/index": "./src/index.ts",
+    });
+
     expect(snapshot).toMatchSnapshot();
   });
 


### PR DESCRIPTION
## Summary
- Expand zshy wildcard export matches into explicit `jsr.json` exports so JSR publish does not receive wildcard subpaths.
- Keep npm `package.json` exports in wildcard form while reusing the existing wildcard discovery results for JSR output.
- Add fixture coverage that verifies wildcard JSR exports become explicit entries.

## Test plan
- `pnpm vitest run test/zshy.test.ts`
- `ReadLints` on `src/main.ts` and `test/zshy.test.ts`