### PR TITLE
fix: preserve ESM diagnostics when CJS is disabled

### DIFF
--- a/src/compile.ts
+++ b/src/compile.ts
@@ -107,12 +107,14 @@ export async function compileProject(config: ProjectOptions, entryPoints: string
   const diagnostics = ts.getPreEmitDiagnostics(program);
 
   if (diagnostics.length > 0) {
-    // Filter out ts1343 errors for CJS builds
+    // Filter out diagnostics that are expected from CJS-only transforms.
     const filteredDiagnostics = diagnostics.filter((d) => {
       if (config.format === "cjs") {
         return d.code !== 1343 && d.code !== 1259;
       }
-    }); // Ignore ts1343 (import.meta not available) for CJS
+
+      return true;
+    });
 
     const errorCount = filteredDiagnostics.filter((d) => d.category === ts.DiagnosticCategory.Error).length;
     const warningCount = filteredDiagnostics.filter((d) => d.category === ts.DiagnosticCategory.Warning).length;

--- a/test/esm-only-error/package.json
+++ b/test/esm-only-error/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "my-pkg",
+  "version": "1.0.0",
+  "type": "module",
+  "zshy": {
+    "exports": {
+      ".": "./src/index.ts"
+    },
+    "cjs": false
+  }
+}

--- a/test/esm-only-error/src/index.ts
+++ b/test/esm-only-error/src/index.ts
@@ -1,0 +1,1 @@
+export const bad: string = 123;

--- a/test/esm-only-error/tsconfig.json
+++ b/test/esm-only-error/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.default.json",
+  "compilerOptions": {
+    "outDir": "./dist"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/test/zshy.test.ts
+++ b/test/zshy.test.ts
@@ -173,6 +173,18 @@ describe("zshy with different tsconfig configurations", () => {
     expect(snapshot).toMatchSnapshot();
   });
 
+  it("should report type errors when commonjs is false", () => {
+    const result = runZshyWithTsconfig("tsconfig.json", {
+      dryRun: true,
+      cwd: process.cwd() + "/test/esm-only-error",
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout).toContain("Skipping CJS build (cjs: false)");
+    expect(result.stdout).toContain("TS2322");
+    expect(result.stdout).toContain("Type 'number' is not assignable to type 'string'.");
+  });
+
   it("should copy exports to jsr.json when jsr.json exists", () => {
     const snapshot = runZshyWithTsconfig("tsconfig.json", {
       dryRun: false,


### PR DESCRIPTION
## Summary
- Preserve TypeScript diagnostics during ESM builds instead of filtering them all out.
- Add a regression fixture for `cjs: false` that verifies type errors are reported and fail the build.

Fixes #63.

## Test plan
- `pnpm vitest run test/zshy.test.ts -t "commonjs is false"`
- `pnpm test`