### PR TITLE
fix: nest types under import/require in generated exports

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -947,26 +947,30 @@ Examples:
             }
 
             // Add standard conditions
-            exportObj.types = relDtsPath;
             if (skipCjs) {
-              // ESM-only: use default condition instead of import
+              // ESM-only: use flat types + default
+              exportObj.types = relDtsPath;
               exportObj.default = relJsPath;
             } else {
-              // Dual CJS/ESM: use import and require
-              exportObj.import = relJsPath;
-              exportObj.require = relJsPath;
+              // Dual CJS/ESM: nest types under import/require for correct resolution
+              exportObj.import = { types: relDtsPath, default: relJsPath };
+              exportObj.require = { types: relDtsPath, default: relJsPath };
             }
 
             newExports[finalExportPath] = exportObj;
           } else if (isSourceFile(sourcePath)) {
             const esmPath = removeExtension(relJsPath) + (isTypeModule ? `.js` : `.mjs`);
             const cjsPath = removeExtension(relJsPath) + (isTypeModule ? `.cjs` : `.js`);
-            // Use ESM type declarations when CJS is skipped, otherwise use CJS declarations
-            const dtsExt = skipCjs ? (isTypeModule ? ".d.ts" : ".d.mts") : isTypeModule ? ".d.cts" : ".d.ts";
-            const dtsPath = removeExtension(relDtsPath) + dtsExt;
+            // Generate separate type declaration paths for ESM and CJS
+            const esmDtsExt = isTypeModule ? ".d.ts" : ".d.mts";
+            const cjsDtsExt = isTypeModule ? ".d.cts" : ".d.ts";
+            const esmDtsPath = removeExtension(relDtsPath) + esmDtsExt;
+            const cjsDtsPath = removeExtension(relDtsPath) + cjsDtsExt;
+            // For flat types field (ESM-only or top-level fallback)
+            const dtsPath = skipCjs ? esmDtsPath : cjsDtsPath;
 
             // Build exports object with proper condition ordering
-            const exportObj: Record<string, string> = {};
+            const exportObj: Record<string, any> = {};
 
             // Add custom conditions first in their original order
             if (config.conditions) {
@@ -982,14 +986,14 @@ Examples:
             }
 
             // Add standard conditions
-            exportObj.types = dtsPath;
             if (skipCjs) {
-              // ESM-only: use default condition instead of import
+              // ESM-only: use flat types + default
+              exportObj.types = esmDtsPath;
               exportObj.default = esmPath;
             } else {
-              // Dual CJS/ESM: use import and require
-              exportObj.import = esmPath;
-              exportObj.require = cjsPath;
+              // Dual CJS/ESM: nest types under import/require for correct resolution
+              exportObj.import = { types: esmDtsPath, default: esmPath };
+              exportObj.require = { types: cjsDtsPath, default: cjsPath };
             }
 
             newExports[exportPath] = exportObj;


### PR DESCRIPTION
## Summary

- Fixes colinhacks/zod#5686: When building dual CJS/ESM packages, the generated `exports` field used a flat `types` condition pointing to `.d.cts` for all entry points
- This caused TypeScript with `module: "nodenext"` to resolve ESM imports to CJS declaration files, resulting in broken type inference (e.g. `z.z.core.$strip` instead of `z.core.$strip`)
- This change generates separate ESM (`.d.ts`) and CJS (`.d.cts`) type declaration paths and nests them under `import` and `require` conditions respectively

## Changes

**For source file entrypoints (dual CJS/ESM builds):**

Before:
```json
".": {
  "types": "./dist/index.d.cts",
  "import": "./dist/index.js",
  "require": "./dist/index.cjs"
}
```

After:
```json
".": {
  "import": {
    "types": "./dist/index.d.ts",
    "default": "./dist/index.js"
  },
  "require": {
    "types": "./dist/index.d.cts",
    "default": "./dist/index.cjs"
  }
}
```

**For wildcard entrypoints:**
Same nesting pattern applied, using the same type declaration path for both import/require since wildcards don't have separate ESM/CJS variants.

**ESM-only builds** remain unchanged (flat `types` + `default`).

## Test plan

- [ ] Run `pnpm test` and update snapshots
- [ ] Verify generated exports have nested types under import/require
- [ ] Verify ESM projects with `module: "nodenext"` resolve to `.d.ts`
- [ ] Verify CJS projects resolve to `.d.cts`